### PR TITLE
Set version to 3.3, 3.8 wouldn't run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.3"
 
 services:
   db:


### PR DESCRIPTION
Had an issue running this with 3.8 in the version.  Setting to version 3.3 seemed to do the trick.  Thank you very much for the great walk through on your site and this repository! 👯 


```
╰─ docker-compose up -d  
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong
 Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions
 under the `services` key, or omit the `version` key and place your service definitions at the root of the file 
to use version 1.

For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/

```
